### PR TITLE
fix(index.ts): fix obsucer mitm bug

### DIFF
--- a/__tests__/misc.ts
+++ b/__tests__/misc.ts
@@ -76,3 +76,17 @@ describe("Serialize reqeust serializes an incoming request", () => {
     expect(ser.parameters.petId).toBe("69");
   });
 });
+
+describe("Mitm internal keepAlive", () => {
+  it("Properly destroys connection with keep alive", async () => {
+    const agent = new https.Agent({ keepAlive: true });
+    for (let i = 1; i < 10000; i++) {
+      await new Promise((resolve, reject) => {
+        https.get("https://example.com", { agent }, res => {
+          res.on("data", d => {});
+          res.on("end", resolve);
+        });
+      });
+    }
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,8 @@ class MockAPI {
         } catch (err) {
           res.statusCode = 500;
           res.end(err.message);
+        } finally {
+          req.destroy();
         }
       });
     }


### PR DESCRIPTION
Mitm has problems when agents like axios want to keep the connection alive. this probably to a
buffer overflow. This is why we destroy the request up on finish sending data
[mitm/#59](https://github.com/moll/node-mitm/issues/59#issuecomment-557630908)