### PR TITLE
fix(index.ts): instantiating only one Mitm Interceptor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,13 +29,14 @@ class MockAPI {
       persist: boolean;
     };
   }[] = [];
-  private static initialized: false;
+  private static initialized = false;
   private static mitm: ReturnType<typeof Mitm>;
   private static mockedAPIs = new Map<string, MockAPI>();
 
   static async mock(pathToFile: string): Promise<MockAPI> {
     if (!this.initialized) {
       this.mitm = Mitm();
+      this.initialized = true;
       this.mitm.on("request", (req, res) => {
         try {
           if (!req.url) {


### PR DESCRIPTION
Fixed an error, where multiple MItm instances got created. This lead to performance problems.