### PR TITLE
fix(matchresponse.ts): now properly matches a url with partial variables

### DIFF
--- a/__tests__/api.yaml
+++ b/__tests__/api.yaml
@@ -243,6 +243,19 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Order"
+  /store/{orderId}order:
+    get:
+      tags:
+        - store
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Order"
 
 components:
   schemas:

--- a/__tests__/misc.ts
+++ b/__tests__/misc.ts
@@ -90,3 +90,42 @@ describe("Mitm internal keepAlive", () => {
     }
   });
 });
+
+describe("Matches also badly written urls", () => {
+  it("Matches a path with an escaped space inside", async () => {
+    const response: string = await new Promise((res, rej) =>
+      https
+        .get("https://petstore.swagger.io/v2/store%20order", resp => {
+          let data = "";
+          resp.on("data", chunk => {
+            data += chunk;
+          });
+          resp.on("end", () => {
+            res(data);
+          });
+        })
+        .on("error", err => {
+          rej(err);
+        })
+    );
+    expect(petStore.getCallCount()).toBe(1);
+  });
+  it("Matches a path with a variable which does not end with }", async () => {
+    const response: string = await new Promise((res, rej) =>
+      https
+        .get("https://petstore.swagger.io/v2/store/69order", resp => {
+          let data = "";
+          resp.on("data", chunk => {
+            data += chunk;
+          });
+          resp.on("end", () => {
+            res(data);
+          });
+        })
+        .on("error", err => {
+          rej(err);
+        })
+    );
+    expect(petStore.getCallCount()).toBe(1);
+  });
+});

--- a/__tests__/petstore.ts
+++ b/__tests__/petstore.ts
@@ -171,22 +171,4 @@ describe("Easily mock APIs", () => {
     );
     expect(petStore.getCallCount()).toBe(1);
   });
-  it("Matches a path with an escaped space inside", async () => {
-    const response: string = await new Promise((res, rej) =>
-      https
-        .get("https://petstore.swagger.io/v2/store%20order", resp => {
-          let data = "";
-          resp.on("data", chunk => {
-            data += chunk;
-          });
-          resp.on("end", () => {
-            res(data);
-          });
-        })
-        .on("error", err => {
-          rej(err);
-        })
-    );
-    expect(petStore.getCallCount()).toBe(1);
-  });
 });

--- a/src/matchResponse.ts
+++ b/src/matchResponse.ts
@@ -64,10 +64,7 @@ export function matchSpec(
           parts.length === urlParts.length &&
           urlParts.every(
             (curr, i) =>
-              (parts[i] &&
-                parts[i].startsWith("{") &&
-                parts[i].endsWith("}")) ||
-              curr === parts[i]
+              (parts[i] && /\{.+\}/.test(parts[i])) || curr === parts[i]
           )
         );
       })
@@ -113,8 +110,9 @@ export function serializeRequest(
   let urlParts = url.pathname.split("/").filter(t => t);
   urlParts = urlParts.slice(urlParts.length - parts.length);
   const parameters: Record<string, string> = parts.reduce((prev, curr, i) => {
-    if (curr.startsWith("{") && curr.endsWith("}")) {
-      return { ...prev, [curr.slice(1, curr.length - 1)]: urlParts[i] };
+    if (/\{.+\}/.test(curr)) {
+      const match = /\{.+\}/.exec(curr)![0];
+      return { ...prev, [match.slice(1, match.length - 1)]: urlParts[i] };
     }
     return prev;
   }, {});


### PR DESCRIPTION
It now matches url parts, which do include a {} but also other letters outside of that