### PR TITLE
fix(index.ts): now returns a transformed response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,10 @@ class MockAPI {
           }
           specs[0].responses.push({
             request: requests[0],
-            response: contentType ? objectValue : value,
+            response:
+              contentType && transformResponse.length !== 0
+                ? objectValue
+                : value,
             code: +code,
           });
           res.end(value);


### PR DESCRIPTION
Previously transformations were not properly stored. This lead to a bunch of problems, so this is
now fixed.